### PR TITLE
Add more descriptive error tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+### 0.2.0 (unreleased)
+
+- Add more descriptive error tracking (#9)
+- Update error tracking event category and action (#9)
+
+### 0.1.0 (2017-02-08)
+
+- Initial public release

--- a/src/analytics/autotrack.js
+++ b/src/analytics/autotrack.js
@@ -84,14 +84,14 @@ export const init = () => {
  *
  *    `fetch('/api.json').catch(trackError);`
  *
- * @param {Error|undefined} error
+ * @param {Error|undefined} err
  * @param {Object=} fieldsObj
  */
-export const trackError = (error, fieldsObj = {}) => {
+export const trackError = (err, fieldsObj = {}) => {
   ga('send', 'event', Object.assign({
-    eventCategory: 'Script',
-    eventAction: 'error',
-    eventLabel: (error && error.stack) || NULL_VALUE,
+    eventCategory: 'Error',
+    eventAction: err.name,
+    eventLabel: `${err.message}\n${err.stack || '(no stack trace)'}`,
     nonInteraction: true,
   }, fieldsObj));
 };
@@ -118,8 +118,8 @@ const trackErrors = () => {
   // `window.__e.q`, as specified in `index.html`.
   const loadErrorEvents = window.__e && window.__e.q || [];
 
-  // Use a different eventAction for uncaught errors.
-  const fieldsObj = {eventAction: 'uncaught error'};
+  // Use a different eventCategory for uncaught errors.
+  const fieldsObj = {eventCategory: 'Uncaught Error'};
 
   // Replay any stored load error events.
   for (let event of loadErrorEvents) {

--- a/src/analytics/base.js
+++ b/src/analytics/base.js
@@ -72,14 +72,14 @@ export const init = () => {
  *
  *    `fetch('/api.json').catch(trackError);`
  *
- * @param {Error|undefined} error
+ * @param {Error|undefined} err
  * @param {Object=} fieldsObj
  */
-export const trackError = (error, fieldsObj = {}) => {
+export const trackError = (err, fieldsObj = {}) => {
   ga('send', 'event', Object.assign({
-    eventCategory: 'Script',
-    eventAction: 'error',
-    eventLabel: (error && error.stack) || NULL_VALUE,
+    eventCategory: 'Error',
+    eventAction: err.name,
+    eventLabel: `${err.message}\n${err.stack || '(no stack trace)'}`,
     nonInteraction: true,
   }, fieldsObj));
 };
@@ -106,8 +106,8 @@ const trackErrors = () => {
   // `window.__e.q`, as specified in `index.html`.
   const loadErrorEvents = window.__e && window.__e.q || [];
 
-  // Use a different eventAction for uncaught errors.
-  const fieldsObj = {eventAction: 'uncaught error'};
+  // Use a different eventCategory for uncaught errors.
+  const fieldsObj = {eventCategory: 'Uncaught Error'};
 
   // Replay any stored load error events.
   for (let event of loadErrorEvents) {

--- a/src/analytics/multiple-trackers.js
+++ b/src/analytics/multiple-trackers.js
@@ -137,14 +137,14 @@ const createTrackers = () => {
  *
  *    `fetch('/api.json').catch(trackError);`
  *
- * @param {Error|undefined} error
+ * @param {Error|undefined} err
  * @param {Object=} fieldsObj
  */
-export const trackError = (error, fieldsObj = {}) => {
+export const trackError = (err, fieldsObj = {}) => {
   gaAll('send', 'event', Object.assign({
-    eventCategory: 'Script',
-    eventAction: 'error',
-    eventLabel: (error && error.stack) || NULL_VALUE,
+    eventCategory: 'Error',
+    eventAction: err.name,
+    eventLabel: `${err.message}\n${err.stack || '(no stack trace)'}`,
     nonInteraction: true,
   }, fieldsObj));
 };
@@ -159,8 +159,8 @@ const trackErrors = () => {
   // `window.__e.q`, as specified in `index.html`.
   const loadErrorEvents = window.__e && window.__e.q || [];
 
-  // Use a different eventAction for uncaught errors.
-  const fieldsObj = {eventAction: 'uncaught error'};
+  // Use a different eventCategory for uncaught errors.
+  const fieldsObj = {eventCategory: 'Uncaught Error'};
 
   // Replay any stored load error events.
   for (let event of loadErrorEvents) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,7 +4,7 @@ const path = require('path');
 module.exports = {
   entry: {
     'index': './src/index.js',
-    'test': ['babel-polyfill', ...glob.sync('./test/*-test.js')],
+    'test': ['babel-polyfill', ...glob.sync('./test/analytics/*-test.js')],
   },
   output: {
     path: path.resolve(__dirname, 'build'),


### PR DESCRIPTION
In some cases the `Error.prototype.stack` property doesn't include the name of the error or the error message. This change adds both of those.

To accommodate this change, the default category has been changed to "Error" from "Script", and the action has changed to the value of the error name.