### PR TITLE
Update hit time calculations to account for the queueTime field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 0.2.0 (unreleased)
 
+- Update hit time calculations to account for the `queueTime` field (#10)
 - Add more descriptive error tracking (#9)
 - Update error tracking event category and action (#9)
 

--- a/src/analytics/autotrack.js
+++ b/src/analytics/autotrack.js
@@ -159,8 +159,9 @@ const trackCustomDimensions = () => {
   ga((tracker) => {
     const originalBuildHitTask = tracker.get('buildHitTask');
     tracker.set('buildHitTask', (model) => {
+      const qt = model.get('queueTime') || 0;
+      model.set(dimensions.HIT_TIME, String(new Date - qt), true);
       model.set(dimensions.HIT_ID, uuid(), true);
-      model.set(dimensions.HIT_TIME, String(+new Date), true);
       model.set(dimensions.HIT_TYPE, model.get('hitType'), true);
       model.set(dimensions.VISIBILITY_STATE, document.visibilityState, true);
 

--- a/src/analytics/base.js
+++ b/src/analytics/base.js
@@ -147,8 +147,9 @@ const trackCustomDimensions = () => {
   ga((tracker) => {
     const originalBuildHitTask = tracker.get('buildHitTask');
     tracker.set('buildHitTask', (model) => {
+      const qt = model.get('queueTime') || 0;
+      model.set(dimensions.HIT_TIME, String(new Date - qt), true);
       model.set(dimensions.HIT_ID, uuid(), true);
-      model.set(dimensions.HIT_TIME, String(+new Date), true);
       model.set(dimensions.HIT_TYPE, model.get('hitType'), true);
       model.set(dimensions.VISIBILITY_STATE, document.visibilityState, true);
 

--- a/src/analytics/multiple-trackers.js
+++ b/src/analytics/multiple-trackers.js
@@ -293,7 +293,6 @@ const sendInitialPageview = () => {
  };
 
 
-
 /**
  * Accepts a custom dimension or metric and returns it's numerical index.
  * @param {string} definition The definition string (e.g. 'dimension1').

--- a/src/analytics/multiple-trackers.js
+++ b/src/analytics/multiple-trackers.js
@@ -200,8 +200,9 @@ const trackCustomDimensions = () => {
   gaAll((tracker) => {
     const originalBuildHitTask = tracker.get('buildHitTask');
     tracker.set('buildHitTask', (model) => {
+      const qt = model.get('queueTime') || 0;
+      model.set(dimensions.HIT_TIME, String(new Date - qt), true);
       model.set(dimensions.HIT_ID, uuid(), true);
-      model.set(dimensions.HIT_TIME, String(+new Date), true);
       model.set(dimensions.HIT_TYPE, model.get('hitType'), true);
       model.set(dimensions.VISIBILITY_STATE, document.visibilityState, true);
 

--- a/test/analytics/autotrack-test.js
+++ b/test/analytics/autotrack-test.js
@@ -100,6 +100,18 @@ describe('analytics/autotrack', () => {
       });
     });
 
+    it('accounts for the queueTime field in hit time calculations', () => {
+      analytics.init();
+      ga('send', 'pageview', {queueTime: 60 * 60 * 1000});
+
+      // Wait for a pageview, a perf event, and another pageview
+      return waitForHits(3).then(() => {
+        const hits = getHits();
+
+        assert(+hits[2].cd5 < +hits[0].cd5);
+      });
+    });
+
     it('includes select autotrack plugins', () => {
       const originalLocation = location.href;
       history.replaceState({}, null, '/test/?foo=bar');

--- a/test/analytics/autotrack-test.js
+++ b/test/analytics/autotrack-test.js
@@ -71,7 +71,6 @@ describe('analytics/autotrack', () => {
       // Wait for a pageview and a perf event.
       return waitForHits(2).then(() => {
         const hits = getHits();
-        console.log(hits);
 
         assert.strictEqual(hits[0].cd1, '1');
         assert(CLIENT_ID_PATTERN.test(hits[0].cd2));

--- a/test/analytics/base-test.js
+++ b/test/analytics/base-test.js
@@ -97,6 +97,18 @@ describe('analytics/base', () => {
       });
     });
 
+    it('accounts for the queueTime field in hit time calculations', () => {
+      analytics.init();
+      ga('send', 'pageview', {queueTime: 60 * 60 * 1000});
+
+      // Wait for a pageview, a perf event, and another pageview
+      return waitForHits(3).then(() => {
+        const hits = getHits();
+
+        assert(+hits[2].cd5 < +hits[0].cd5);
+      });
+    });
+
     it('sends an initial pageview with the hit source', () => {
       analytics.init();
 

--- a/test/analytics/multiple-trackers-test.js
+++ b/test/analytics/multiple-trackers-test.js
@@ -233,7 +233,6 @@ const waitForHits = (count) => {
       if (navigator.sendBeacon.callCount === count) {
         resolve();
       } else if (new Date - startTime > 2000) {
-        console.log(getHits());
         reject(new Error(`Timed out waiting for ${count} hits ` +
             `(${navigator.sendBeacon.callCount} hits received).`));
       } else {

--- a/test/analytics/multiple-trackers-test.js
+++ b/test/analytics/multiple-trackers-test.js
@@ -129,6 +129,20 @@ describe('analytics/multiple-trackers', () => {
       });
     });
 
+    it('accounts for the queueTime field in hit time calculations', () => {
+      analytics.init();
+      ga('prod.send', 'pageview', {queueTime: 60 * 60 * 1000});
+      ga('test.send', 'pageview', {queueTime: 60 * 60 * 1000});
+
+      // Wait for two pageviews, a perf event, and then two more pageviews.
+      return waitForHits(5).then(() => {
+        const hits = getHits();
+
+        assert(+hits[3].cd5 < +hits[0].cd5);
+        assert(+hits[4].cd5 < +hits[0].cd5);
+      });
+    });
+
     it('includes select autotrack plugins', () => {
       const originalLocation = location.href;
       history.replaceState({}, null, '/test/?foo=bar');


### PR DESCRIPTION
In some cases hits are sent after they occur and the [queueTime](https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#queueTime) field is used to indicate the time offset. This field needs to be taken into consideration for accurate hit ordering in reports via the hit time custom dimension.