### PR TITLE
Fix comment typos: mapping & metrics

### DIFF
--- a/src/analytics/autotrack.js
+++ b/src/analytics/autotrack.js
@@ -33,7 +33,7 @@ const NULL_VALUE = '(not set)';
 
 
 /**
- * A maping between custom dimension names and their indexes.
+ * A mapping between custom dimension names and their indexes.
  */
 const dimensions = {
   TRACKING_VERSION: 'dimension1',
@@ -49,7 +49,7 @@ const dimensions = {
 
 
 /**
- * A maping between custom dimension names and their indexes.
+ * A mapping between custom metric names and their indexes.
  */
 const metrics = {
   RESPONSE_END_TIME: 'metric1',

--- a/src/analytics/base.js
+++ b/src/analytics/base.js
@@ -25,7 +25,7 @@ const NULL_VALUE = '(not set)';
 
 
 /**
- * A maping between custom dimension names and their indexes.
+ * A mapping between custom dimension names and their indexes.
  */
 const dimensions = {
   TRACKING_VERSION: 'dimension1',
@@ -40,7 +40,7 @@ const dimensions = {
 
 
 /**
- * A maping between custom dimension names and their indexes.
+ * A mapping between custom metric names and their indexes.
  */
 const metrics = {
   RESPONSE_END_TIME: 'metric1',

--- a/src/analytics/multiple-trackers.js
+++ b/src/analytics/multiple-trackers.js
@@ -43,7 +43,7 @@ const NULL_VALUE = '(not set)';
 
 
 /**
- * A maping between custom dimension names and their indexes.
+ * A mapping between custom dimension names and their indexes.
  */
 const dimensions = {
   TRACKING_VERSION: 'dimension1',
@@ -59,7 +59,7 @@ const dimensions = {
 
 
 /**
- * A maping between custom dimension names and their indexes.
+ * A mapping between custom metric names and their indexes.
  */
 const metrics = {
   RESPONSE_END_TIME: 'metric1',


### PR DESCRIPTION
* Mapping should be spelled with two p's.
* The comment for the metrics mapping should refer to custom metric names,
  not custom dimension names.

Thanks for the interesting and helpful blog post & code